### PR TITLE
Fix compilation error due to `unsafe' keyword

### DIFF
--- a/src/connection_settings.rs
+++ b/src/connection_settings.rs
@@ -41,14 +41,14 @@ pub struct ConnectionSettings {
 
 impl ConnectionSettings {
     /// Timestamp in us
-    pub fn get_timestamp(&self, at: Instant) -> i32 {
+    pub fn get_timestamp(&self, at: Instant) -> u64 {
         let elapsed = at - self.socket_start_time;
 
-        (elapsed.as_secs() * 1_000_000 + (u64::from(elapsed.subsec_nanos()) / 1_000)) as i32
+        elapsed.as_secs() * 1_000_000 + (u64::from(elapsed.subsec_nanos()) / 1_000)
     }
 
     /// Timestamp in us
-    pub fn get_timestamp_now(&self) -> i32 {
+    pub fn get_timestamp_now(&self) -> u64 {
         self.get_timestamp(Instant::now())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::all)]
-#![forbid(unsafe)]
+#![forbid(unsafe_code)]
 
 mod builder;
 mod channel;

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -618,7 +618,7 @@ where
                 .next_msg_tsbpd(tsbpd, self.settings.socket_start_time)
             {
                 return Ok(Async::Ready(Some((
-                    self.settings.socket_start_time + Duration::from_micros(ts as u64),
+                    self.settings.socket_start_time + Duration::from_micros(ts),
                     p,
                 ))));
             }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -217,7 +217,7 @@ where
                         let now = self.get_timestamp_now();
                         self.sock.start_send((
                             Packet::Control(ControlPacket {
-                                timestamp: now,
+                                timestamp: now as i32,
                                 dest_sockid: self.settings.remote_sockid,
                                 control_type: ControlTypes::Ack2(*ack_seq_num),
                             }),
@@ -401,7 +401,7 @@ where
                 self.next_message_number - 1
             },
             seq_number: self.get_new_sequence_number(),
-            timestamp: self.get_timestamp(time),
+            timestamp: self.get_timestamp(time) as i32,
             payload,
         };
 
@@ -411,11 +411,11 @@ where
         Some(Packet::Data(pack))
     }
 
-    fn get_timestamp_now(&self) -> i32 {
+    fn get_timestamp_now(&self) -> u64 {
         self.settings.get_timestamp_now()
     }
 
-    fn get_timestamp(&self, at: Instant) -> i32 {
+    fn get_timestamp(&self, at: Instant) -> u64 {
         self.settings.get_timestamp(at)
     }
 }
@@ -570,7 +570,7 @@ where
             self.sock.start_send((
                 Packet::Control(ControlPacket {
                     dest_sockid: self.settings.remote_sockid,
-                    timestamp: ts,
+                    timestamp: ts as i32,
                     control_type: ControlTypes::Shutdown,
                 }),
                 self.settings.remote,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -2,7 +2,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct Stats {
     /// Timestamp that the stats was captured, in us from socket start
-    pub timestamp: i32,
+    pub timestamp: u64,
 
     /// Round trip time, in us
     pub rtt: i32,


### PR DESCRIPTION
After revision f6c8909, the following compilation error occurs:
```
error: expected identifier, found keyword `unsafe`
 --> src/lib.rs:2:11
  |
2 | #![forbid(unsafe)]
  |           ^^^^^^ expected identifier, found keyword
```
I think you intended `[forbid (unsafe_code)] '.