### PR TITLE
Fixed the memory boost difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Reference implementation is available at https://github.com/haivision/srt
 
 Running under massif, the maximum memory usage is around 6KB for transmitting video. for srt-rs.
 
-For the reference implementation, this number grows to 1.2MB, so around a 2X difference. 
+For the reference implementation, this number grows to 1.2MB, so around a 200X difference. 
 
 # Thread Efficiency
 


### PR DESCRIPTION
6000B vs 1200000B is not just a 2x difference but a 200x different.. 
Let's highlight this positive achievement!