### PR TITLE
client/server connection as machine

### DIFF
--- a/src/pending_connection/connect.rs
+++ b/src/pending_connection/connect.rs
@@ -1,20 +1,217 @@
 use std::net::{IpAddr, SocketAddr};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use failure::Error;
-
-use futures::prelude::*;
 use futures::select;
-
-use log::{debug, info, warn};
+use futures::prelude::*;
+use tokio::time::Instant;
 use tokio::time::interval;
 
-use crate::packet::{
-    ControlPacket, ControlTypes, HandshakeControlInfo, HandshakeVSInfo, Packet, ShakeType,
-    SocketType, SrtControlPacket, SrtHandshake, SrtShakeFlags,
-};
+use log::warn;
+
+use crate::packet::*;
 use crate::util::get_packet;
-use crate::{Connection, ConnectionSettings, SocketID, SrtVersion};
+use crate::{Connection, ConnectionSettings, DataPacket, SeqNumber, SocketID, SrtVersion};
+
+use ConnectError::*;
+use ConnectState::*;
+
+pub struct ConnectConfiguration {
+    remote: SocketAddr,
+    local_sockid: SocketID,
+    local_addr: IpAddr,
+    tsbpd_latency: Duration,
+}
+
+#[derive(Clone)]
+pub enum ConnectState {
+    Configured(SeqNumber),
+    InductionResponseWait(Packet),
+    ConclusionResponseWait(Packet),
+    Connected(ConnectionSettings),
+}
+
+impl ConnectState {
+    pub fn new() -> ConnectState {
+        Configured(rand::random())
+    }
+}
+
+#[derive(Debug)]
+pub enum ConnectError {
+    //#[error("Expected Control packet, expected: {0} found: {1}")]
+    ControlExpected(ShakeType, DataPacket),
+    //#[error("Expected Handshake packet, expected: {0} found: {1}")]
+    HandshakeExpected(ShakeType, ControlTypes),
+    //#[error("Expected Induction (1) packet, found: {0}")]
+    InductionExpected(HandshakeControlInfo),
+    //#[error("Expected packets from different host, expected: {0} found: {1}")]
+    UnexpectedHost(SocketAddr, SocketAddr),
+    //#[error("Expected Conclusion (-1) packet, found: {0}")]
+    ConclusionExpected(HandshakeControlInfo),
+    //#[error("Unsupported protocol version, expected: v5 found v{0}")]
+    UnsupportedProtocolVersion(u32),
+    // TODO: why don't we validate the cookie on responses
+    //#[error("Received invalid cookie handshake from [address], expected: {0} found {1}")]
+    //InvalidHandshakeCookie(i32, i32),
+    // TODO: why don't we validate we have an SRT response
+    //#[error("Expected SRT handshake request in conclusion handshake, found {0}")]
+    //SrtHandshakeExpected(HandshakeControlInfo),
+}
+
+pub struct Connect(ConnectConfiguration, ConnectState);
+
+pub type ConnectResult = Result<Option<(Packet, SocketAddr)>, ConnectError>;
+
+impl Connect {
+    fn on_start(&mut self, init_seq_num: SeqNumber) -> ConnectResult {
+        let config = &self.0;
+        let packet = Packet::Control(ControlPacket {
+            dest_sockid: SocketID(0),
+            timestamp: 0, // TODO: this is not zero in the reference implementation
+            control_type: ControlTypes::Handshake(HandshakeControlInfo {
+                init_seq_num,
+                max_packet_size: 1500, // TODO: take as a parameter
+                max_flow_size: 8192,   // TODO: take as a parameter
+                socket_id: config.local_sockid,
+                shake_type: ShakeType::Induction,
+                peer_addr: config.local_addr,
+                syn_cookie: 0,
+                info: HandshakeVSInfo::V4(SocketType::Datagram),
+            }),
+        });
+        self.1 = InductionResponseWait(packet.clone());
+        Ok(Some((packet, self.0.remote)))
+    }
+
+    pub fn wait_for_induction(
+        &mut self,
+        from: SocketAddr,
+        timestamp: i32,
+        info: HandshakeControlInfo,
+    ) -> ConnectResult {
+        let config = &self.0;
+        match (info.shake_type, info.info.version(), from) {
+            (ShakeType::Induction, 5, from) if from == config.remote => {
+                // send back a packet with the same syn cookie
+                let packet = Packet::Control(ControlPacket {
+                    timestamp,
+                    dest_sockid: SocketID(0),
+                    control_type: ControlTypes::Handshake(HandshakeControlInfo {
+                        shake_type: ShakeType::Conclusion,
+                        socket_id: config.local_sockid,
+                        info: HandshakeVSInfo::V5 {
+                            crypto_size: 0, // TODO: implement
+                            ext_hs: Some(SrtControlPacket::HandshakeRequest(SrtHandshake {
+                                version: SrtVersion::CURRENT,
+                                // TODO: this is hyper bad, don't blindly set send flag
+                                // if you don't pass TSBPDRCV, it doens't set the latency correctly for some reason. Requires more research
+                                peer_latency: Duration::from_secs(0), // TODO: research
+                                flags: SrtShakeFlags::TSBPDSND | SrtShakeFlags::TSBPDRCV, // TODO: the reference implementation sets a lot more of these, research
+                                latency: config.tsbpd_latency,
+                            })),
+                            ext_km: None,
+                            // ext_km: self.crypto.as_mut().map(|manager| {
+                            //     SrtControlPacket::KeyManagerRequest(SrtKeyMessage {
+                            //         pt: 2,       // TODO: what is this
+                            //         sign: 8_233, // TODO: again
+                            //         keki: 0,
+                            //         cipher: CipherType::CTR,
+                            //         auth: 0,
+                            //         se: 2,
+                            //         salt: Vec::from(manager.salt()),
+                            //         even_key: Some(manager.wrap_key().unwrap()),
+                            //         odd_key: None,
+                            //         wrap_data: [0; 8],
+                            //     })
+                            // }),
+                            ext_config: None,
+                        },
+                        ..info
+                    }),
+                });
+                self.1 = ConclusionResponseWait(packet.clone());
+                Ok(Some((packet, from)))
+            }
+            (ShakeType::Induction, 5, from) => Err(UnexpectedHost(config.remote, from)),
+            (ShakeType::Induction, version, _) => Err(UnsupportedProtocolVersion(version)),
+            (_, _, _) => Err(InductionExpected(info)),
+        }
+    }
+
+    fn wait_for_conclusion(
+        &mut self,
+        from: SocketAddr,
+        info: HandshakeControlInfo,
+    ) -> ConnectResult {
+        let config = &self.0;
+        match (info.shake_type, info.info.version(), from) {
+            (ShakeType::Conclusion, 5, from) if from == config.remote => {
+                let latency = match info.info {
+                    HandshakeVSInfo::V5 {
+                        ext_hs: Some(SrtControlPacket::HandshakeResponse(hs)),
+                        ..
+                    } => hs.latency,
+                    _ => {
+                        warn!("Did not get SRT handhsake in conclusion handshake packet, using latency from connector's end");
+                        config.tsbpd_latency
+                    }
+                };
+
+                self.1 = Connected(ConnectionSettings {
+                    remote: config.remote,
+                    max_flow_size: info.max_flow_size,
+                    max_packet_size: info.max_packet_size,
+                    init_seq_num: info.init_seq_num,
+                    // restamp the socket start time, so TSBPD works correctly.
+                    // TODO: technically it would be 1 rtt off....
+                    socket_start_time: Instant::now().into_std(),
+                    local_sockid: config.local_sockid,
+                    remote_sockid: info.socket_id,
+                    tsbpd_latency: latency,
+                });
+                // TODO: no handshake retransmit packet needed? is this right? Needs testing.
+
+                Ok(None)
+            }
+            (ShakeType::Conclusion, 5, from) => Err(UnexpectedHost(config.remote, from)),
+            (ShakeType::Conclusion, version, _) => Err(UnsupportedProtocolVersion(version)),
+            (ShakeType::Induction, _, _) => Ok(None),
+            (_, _, _) => Err(ConclusionExpected(info)),
+        }
+    }
+
+    pub fn next_packet(&mut self, next: (Packet, SocketAddr)) -> ConnectResult {
+        let (packet, from) = next;
+        match (self.1.clone(), packet) {
+            (InductionResponseWait(_), Packet::Control(control)) => {
+                match control.control_type {
+                    ControlTypes::Handshake(shake) =>
+                        self.wait_for_induction(from, control.timestamp,shake),
+                    control_type => Err(HandshakeExpected(ShakeType::Induction, control_type)),
+                }
+            },
+            (ConclusionResponseWait(_), Packet::Control(control)) => {
+                match control.control_type {
+                    ControlTypes::Handshake(shake) =>
+                        self.wait_for_conclusion(from, shake),
+                    control_type => Err(HandshakeExpected(ShakeType::Induction, control_type)),
+                }
+            },
+            (_, Packet::Data(data)) => Err(ControlExpected(ShakeType::Induction, data)),
+            (_, _) => Ok(None),
+        }
+    }
+
+    pub fn next_tick(&mut self, _now: Instant) -> ConnectResult {
+        match self.1.clone() {
+            Configured(init_seq_num) => self.on_start(init_seq_num),
+            InductionResponseWait(request_packet) => Ok(Some((request_packet, self.0.remote))),
+            ConclusionResponseWait(request_packet) => Ok(Some((request_packet, self.0.remote))),
+            _ => Ok(None),
+        }
+    }
+}
 
 pub async fn connect<T>(
     sock: &mut T,
@@ -29,180 +226,40 @@ where
         + Sink<(Packet, SocketAddr), Error = Error>
         + Unpin,
 {
-    info!("Got hanshake from {}", remote);
-    let mut send_interval = interval(Duration::from_millis(100));
+    let mut connect = Connect(
+        ConnectConfiguration {
+            remote,
+            local_sockid,
+            local_addr,
+            tsbpd_latency,
+        },
+        ConnectState::new(),
+    );
 
-    let (timestamp, hs_info) =
-        get_initial_handshake(sock, local_addr, local_sockid, remote).await?;
-
-    // send back a packet with the same syn cookie
-    let pack = Packet::Control(ControlPacket {
-        dest_sockid: SocketID(0),
-        timestamp,
-        control_type: ControlTypes::Handshake(HandshakeControlInfo {
-            shake_type: ShakeType::Conclusion,
-            socket_id: local_sockid,
-            info: HandshakeVSInfo::V5 {
-                crypto_size: 0, // TODO: implement
-                ext_hs: Some(SrtControlPacket::HandshakeRequest(SrtHandshake {
-                    version: SrtVersion::CURRENT,
-                    // TODO: this is hyper bad, don't blindly set send flag
-                    // if you don't pass TSBPDRCV, it doens't set the latency correctly for some reason. Requires more research
-                    peer_latency: Duration::from_secs(0), // TODO: research
-                    flags: SrtShakeFlags::TSBPDSND | SrtShakeFlags::TSBPDRCV, // TODO: the reference implementation sets a lot more of these, research
-                    latency: tsbpd_latency,
-                })),
-                ext_km: None,
-                // ext_km: self.crypto.as_mut().map(|manager| {
-                //     SrtControlPacket::KeyManagerRequest(SrtKeyMessage {
-                //         pt: 2,       // TODO: what is this
-                //         sign: 8_233, // TODO: again
-                //         keki: 0,
-                //         cipher: CipherType::CTR,
-                //         auth: 0,
-                //         se: 2,
-                //         salt: Vec::from(manager.salt()),
-                //         even_key: Some(manager.wrap_key().unwrap()),
-                //         odd_key: None,
-                //         wrap_data: [0; 8],
-                //     })
-                // }),
-                ext_config: None,
-            },
-            ..hs_info
-        }),
-    });
-
-    sock.send((pack.clone(), remote)).await?;
-
+    let mut tick_interval = interval(Duration::from_millis(100));
     loop {
-        let (packet, from) = select! {
-            _ = send_interval.tick().fuse() => {sock.send((pack.clone(), remote)).await?; continue},
-            res = get_packet(sock).fuse() => res?
+        let result = select! {
+            now = tick_interval.tick().fuse() => connect.next_tick(now),
+            packet = get_packet(sock).fuse() => connect.next_packet(packet?),
         };
-        if let Packet::Control(ControlPacket {
-            dest_sockid,
-            control_type:
-                ControlTypes::Handshake(
-                    info @ HandshakeControlInfo {
-                        shake_type: ShakeType::Conclusion,
-                        ..
-                    },
-                ),
-            ..
-        }) = packet
-        {
-            if from != remote {
-                warn!("Got packet from {}, expected {}", from, remote)
-            }
-            if dest_sockid != local_sockid {
-                warn!(
-                    "Unexpected destination socket id, expected {:?}, got {:?}",
-                    local_sockid, dest_sockid
-                );
-                continue;
-            }
-            let latency = if let HandshakeVSInfo::V5 {
-                ext_hs: Some(SrtControlPacket::HandshakeResponse(hs)),
-                ..
-            } = info.info
-            {
-                hs.latency
-            } else {
-                warn!("Did not get SRT handhsake in conclusion handshake packet, using latency from connector's end");
-                tsbpd_latency
-            };
 
-            info!(
-                "Got second handshake, connection established to {} with latency {:?}",
-                remote, latency
-            );
-            return Ok(Connection {
-                settings: ConnectionSettings {
-                    remote,
-                    max_flow_size: info.max_flow_size,
-                    max_packet_size: info.max_packet_size,
-                    init_seq_num: info.init_seq_num,
-                    socket_start_time: Instant::now(), // restamp the socket start time, so TSBPD works correctly. TODO: technically it would be 1 rtt off....
-                    local_sockid,
-                    remote_sockid: info.socket_id,
-                    tsbpd_latency: latency,
-                },
-                // TODO: is this right? Needs testing.
-                hs_returner: Box::new(move |_| None),
-            });
+        match result {
+            Ok(Some(packet)) => {
+                sock.send(packet).await?;
+            }
+            Err(e) => {
+                eprintln!("{:?}", e);
+            }
+            _ => {}
+        }
+        match connect.1.clone() {
+            Connected(settings) => {
+                return Ok(Connection {
+                    settings,
+                    hs_returner: Box::new(move |_| None),
+                });
+            }
+            _ => {}
         }
     }
-}
-
-async fn get_initial_handshake<T>(
-    sock: &mut T,
-    local_addr: IpAddr,
-    local_sockid: SocketID,
-    remote: SocketAddr,
-) -> Result<(i32, HandshakeControlInfo), Error>
-where
-    T: Stream<Item = Result<(Packet, SocketAddr), Error>>
-        + Sink<(Packet, SocketAddr), Error = Error>
-        + Unpin,
-{
-    let mut send_interval = interval(Duration::from_millis(100));
-
-    info!("Connecting to {}...", remote);
-
-    let request_packet = Packet::Control(ControlPacket {
-        dest_sockid: SocketID(0),
-        timestamp: 0, // TODO: this is not zero in the reference implementation
-        control_type: ControlTypes::Handshake(HandshakeControlInfo {
-            init_seq_num: rand::random(),
-            max_packet_size: 1500, // TODO: take as a parameter
-            max_flow_size: 8192,   // TODO: take as a parameter
-            socket_id: local_sockid,
-            shake_type: ShakeType::Induction,
-            peer_addr: local_addr,
-            syn_cookie: 0,
-            info: HandshakeVSInfo::V4(SocketType::Datagram),
-        }),
-    });
-
-    sock.send((request_packet.clone(), remote)).await?;
-
-    info!("Sent first packet to {}", remote);
-
-    // get first response packet
-    let (timestamp, hs_info) = loop {
-        // just drop the future that didn't finish first
-        let (packet, addr) = select! {
-            _ = send_interval.tick().fuse() => {sock.send((request_packet.clone(), remote)).await?; continue},
-            res = get_packet(sock).fuse() => res?
-        };
-
-        debug!("Got packet from {}", addr);
-        // make sure the socket id and packet type match
-        if let Packet::Control(ControlPacket {
-            timestamp,
-            control_type: ControlTypes::Handshake(info @ HandshakeControlInfo { .. }),
-            ..
-        }) = packet
-        {
-            if info.shake_type != ShakeType::Induction {
-                info!(
-                    "Expected Induction (1) packet, got {:?} ({})",
-                    info.shake_type, info.shake_type as u32
-                );
-                continue;
-            }
-            if addr != remote {
-                warn!("Expected packet from {}, got {}", remote, addr);
-                continue;
-            }
-            if info.info.version() != 5 {
-                warn!("Handshake was HSv4, expected HSv5");
-                continue;
-            }
-            break (timestamp, info);
-        }
-    };
-
-    Ok((timestamp, hs_info))
 }

--- a/src/pending_connection/listen.rs
+++ b/src/pending_connection/listen.rs
@@ -1,18 +1,227 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use failure::{bail, Error};
+use failure::Error;
 use futures::prelude::*;
-use log::{debug, info, warn};
+use tokio::time::Instant;
 
-use crate::packet::{
-    ControlPacket, ControlTypes, HandshakeControlInfo, HandshakeVSInfo, Packet, ShakeType,
-    SrtControlPacket, SrtHandshake,
-};
+use crate::packet::*;
 use crate::util::get_packet;
-use crate::{Connection, ConnectionSettings, SocketID};
+use crate::{Connection, ConnectionSettings, DataPacket, SocketID};
+
+use ListenState::*;
+use ListenError::*;
+
+pub struct Listen(ListenConfiguration, ListenState);
+
+pub struct ListenConfiguration {
+    local_socket_id: SocketID,
+    tsbpd_latency: Duration,
+}
+
+#[derive(Clone)]
+pub struct ConclusionWaitState {
+    timestamp: i32,
+    from: (std::net::SocketAddr, crate::SocketID),
+    cookie: i32,
+    induction_response: crate::Packet,
+}
+
+#[derive(Clone)]
+pub enum ListenState {
+    InductionWait,
+    ConclusionWait(std::sync::Arc<ConclusionWaitState>),
+    Connected(Packet, ConnectionSettings),
+}
+
+#[derive(Debug)]
+pub enum ListenError {
+    //#[error("Expected Control packet, expected: {0} found: {1}")]
+    ControlExpected(ShakeType, DataPacket),
+    //#[error("Expected Handshake packet, expected: {0} found: {1}")]
+    HandshakeExpected(ShakeType, ControlTypes),
+    //#[error("Expected Induction (1) packet, found: {0}")]
+    InductionExpected(HandshakeControlInfo),
+    //#[error("Expected Conclusion (-1) packet, found: {0}")]
+    ConclusionExpected(HandshakeControlInfo),
+    //#[error("Unsupported protocol version, expected: v5 found v{0}")]
+    UnsupportedProtocolVersion(u32),
+    //#[error("Received invalid cookie handshake from [address], expected: {0} found {1}")]
+    InvalidHandshakeCookie(i32, i32),
+    //#[error("Expected SRT handshake request in conclusion handshake, found {0}")]
+    SrtHandshakeExpected(HandshakeControlInfo),
+}
+
+type ListenResult = Result<Option<(Packet, SocketAddr)>, ListenError>;
+
+impl Listen {
+    fn wait_for_induction(
+        &mut self,
+        from: SocketAddr,
+        timestamp: i32,
+        shake: HandshakeControlInfo,
+    ) -> ListenResult {
+        match shake.shake_type {
+            ShakeType::Induction => {
+                // https://tools.ietf.org/html/draft-gg-udt-03#page-9
+                // When the server first receives the connection request from a client,
+                // it generates a cookie value according to the client address and a
+                // secret key and sends it back to the client. The client must then send
+                // back the same cookie to the server.
+
+                // generate the cookie, which is just a hash of the address
+                // TODO: the reference impl uses the time, maybe we should here
+                let cookie = {
+                    let mut hasher = DefaultHasher::new();
+                    shake.peer_addr.hash(&mut hasher);
+                    hasher.finish() as i32 // this will truncate, which is fine
+                };
+
+                // we expect HSv5, so upgrade it
+                // construct a packet to send back
+                let induction_response = Packet::Control(ControlPacket {
+                    timestamp,
+                    dest_sockid: shake.socket_id,
+                    control_type: ControlTypes::Handshake(HandshakeControlInfo {
+                        syn_cookie: cookie,
+                        socket_id: self.0.local_socket_id,
+                        info: HandshakeVSInfo::V5 {
+                            crypto_size: 0,
+                            ext_hs: None,
+                            ext_km: None,
+                            ext_config: None,
+                        },
+                        ..shake
+                    }),
+                });
+
+                // save induction message for potential later retransmit
+                let save_induction_response = induction_response.clone();
+                self.1 = ConclusionWait(
+                    ConclusionWaitState {
+                        timestamp,
+                        from: (from, shake.socket_id),
+                        cookie,
+                        induction_response: save_induction_response,
+                    }
+                    .into(),
+                );
+                Ok(Some((induction_response, from)))
+            }
+            _ => Err(InductionExpected(shake)),
+        }
+    }
+
+    fn wait_for_conclusion(
+        &mut self,
+        from: SocketAddr,
+        timestamp: i32,
+        state: &ConclusionWaitState,
+        shake: HandshakeControlInfo,
+    ) -> ListenResult {
+        // https://tools.ietf.org/html/draft-gg-udt-03#page-10
+        // The server, when receiving a handshake packet and the correct cookie,
+        // compares the packet size and maximum window size with its own values
+        // and set its own values as the smaller ones. The result values are
+        // also sent back to the client by a response handshake packet, together
+        // with the server's version and initial sequence number. The server is
+        // ready for sending/receiving data right after this step is finished.
+        // However, it must send back response packet as long as it receives any
+        // further handshakes from the same client.
+
+        match (shake.shake_type, shake.info.version(), shake.syn_cookie) {
+            (ShakeType::Induction, _, _) => Ok(Some((state.induction_response.clone(), from))),
+            // first induction received, wait for response (with cookie)
+            (ShakeType::Conclusion, 5, syn_cookie) if syn_cookie == state.cookie => {
+                let (srt_handshake, crypto_size) = match &shake.info {
+                    HandshakeVSInfo::V5 {
+                        ext_hs: Some(SrtControlPacket::HandshakeRequest(hs)),
+                        crypto_size,
+                        ..
+                    } => Ok((hs, *crypto_size)),
+                    _ => Err(SrtHandshakeExpected(shake.clone())),
+                }?;
+
+                let latency = Duration::max(srt_handshake.latency, self.0.tsbpd_latency);
+
+                // construct a packet to send back
+                let resp_handshake = Packet::Control(ControlPacket {
+                    timestamp,
+                    dest_sockid: shake.socket_id,
+                    control_type: ControlTypes::Handshake(HandshakeControlInfo {
+                        syn_cookie: state.cookie,
+                        socket_id: self.0.local_socket_id,
+                        info: HandshakeVSInfo::V5 {
+                            ext_hs: Some(SrtControlPacket::HandshakeResponse(SrtHandshake {
+                                latency,
+                                ..*srt_handshake
+                            })),
+                            ext_km: None,
+                            ext_config: None,
+                            crypto_size,
+                        },
+                        ..shake
+                    }),
+                });
+
+                // select the smaller packet size and max window size
+                // TODO: allow configuration of these parameters, for now just
+                // use the remote ones
+
+                // finish the connection
+                let settings = ConnectionSettings {
+                    init_seq_num: shake.init_seq_num,
+                    remote_sockid: shake.socket_id,
+                    remote: from,
+                    max_flow_size: 16000, // TODO: what is this?
+                    max_packet_size: shake.max_packet_size,
+                    local_sockid: self.0.local_socket_id,
+                    socket_start_time: Instant::now().into_std(), // restamp the socket start time, so TSBPD works correctly
+                    tsbpd_latency: latency,
+                };
+
+                self.1 = Connected(resp_handshake.clone(), settings);
+
+                Ok(Some((resp_handshake, from)))
+            }
+            (ShakeType::Conclusion, 5, syn_cookie) => Err(InvalidHandshakeCookie(
+                state.cookie,
+                syn_cookie,
+            )),
+            (ShakeType::Conclusion, version, _) => Err(UnsupportedProtocolVersion(version)),
+            (_, _, _) => Err(ConclusionExpected(shake)),
+        }
+    }
+
+    pub fn next_packet(&mut self, next: (Packet, SocketAddr)) -> ListenResult {
+        let (packet, from) = next;
+        match (self.1.clone(), packet) {
+            (InductionWait, Packet::Control(control)) => match control.control_type {
+                ControlTypes::Handshake(shake) => {
+                    self.wait_for_induction(from, control.timestamp, shake)
+                }
+                control_type => Err(HandshakeExpected(ShakeType::Induction, control_type)),
+            },
+            (InductionWait, Packet::Data(data)) => Err(ControlExpected(ShakeType::Induction, data)),
+            (ConclusionWait(state), Packet::Control(control)) => {
+                match (control.timestamp, control.control_type) {
+                    (timestamp, ControlTypes::Handshake(shake)) => {
+                        self.wait_for_conclusion(from, timestamp, &state, shake)
+                    }
+                    (_, control_type) => {
+                        Err(HandshakeExpected(ShakeType::Conclusion, control_type))
+                    }
+                }
+            }
+            (ConclusionWait(_), Packet::Data(data)) => {
+                Err(ControlExpected(ShakeType::Conclusion, data))
+            }
+            _ => Ok(None),
+        }
+    }
+}
 
 pub async fn listen<T>(
     sock: &mut T,
@@ -24,211 +233,33 @@ where
         + Sink<(Packet, SocketAddr), Error = Error>
         + Unpin,
 {
-    info!("Listening...");
-
-    // keep on retrying
-    let (cookie, from, induction_pkt) = get_handshake(sock, local_sockid).await?;
-
-    info!("Got induction shake from {}", from);
-
-    let (latency, shake, resp_handshake) = get_conclusion(
-        sock,
-        &induction_pkt,
-        cookie,
-        local_sockid,
-        tsbpd_latency,
-        &from,
-    )
-    .await?;
-    // select the smaller packet size and max window size
-    // TODO: allow configuration of these parameters, for now just
-    // use the remote ones
-
-    // finish the connection
-    Ok(Connection {
-        settings: ConnectionSettings {
-            init_seq_num: shake.init_seq_num,
-            remote_sockid: shake.socket_id,
-            remote: from,
-            max_flow_size: 16000, // TODO: what is this?
-            max_packet_size: shake.max_packet_size,
-            local_sockid,
-            socket_start_time: Instant::now(), // restamp the socket start time, so TSBPD works correctly
-            tsbpd_latency: latency,
+    let mut listen = Listen(
+        ListenConfiguration {
+            local_socket_id: local_sockid,
+            tsbpd_latency,
         },
-        hs_returner: Box::new(move |_| Some(resp_handshake.clone())),
-    })
-}
+        InductionWait,
+    );
 
-async fn get_handshake<
-    T: Stream<Item = Result<(Packet, SocketAddr), Error>>
-        + Sink<(Packet, SocketAddr), Error = Error>
-        + Unpin,
->(
-    sock: &mut T,
-    local_sockid: SocketID,
-) -> Result<(i32, SocketAddr, Packet), Error> {
     loop {
-        let (packet, from) = get_packet(sock).await?;
-
-        if let Packet::Control(ControlPacket {
-            control_type: ControlTypes::Handshake(shake),
-            timestamp,
-            ..
-        }) = packet
-        {
-            if shake.shake_type != ShakeType::Induction {
-                info!(
-                    "Expected Induction (1), got {:?} ({})",
-                    shake.shake_type, shake.shake_type as u32
-                );
-                continue;
+        let packet = get_packet(sock).await?;
+        match listen.next_packet(packet) {
+            Ok(Some(packet)) => {
+                sock.send(packet).await?;
             }
-
-            // https://tools.ietf.org/html/draft-gg-udt-03#page-9
-            // When the server first receives the connection request from a client,
-            // it generates a cookie value according to the client address and a
-            // secret key and sends it back to the client. The client must then send
-            // back the same cookie to the server.
-
-            // generate the cookie, which is just a hash of the address
-            // TODO: the reference impl uses the time, maybe we should here
-            let cookie = {
-                let mut hasher = DefaultHasher::new();
-                shake.peer_addr.hash(&mut hasher);
-                hasher.finish() as i32 // this will truncate, which is fine
-            };
-
-            // we expect HSv5, so upgrade it
-
-            // construct a packet to send back
-            let resp_handshake = Packet::Control(ControlPacket {
-                timestamp,
-                dest_sockid: shake.socket_id,
-                control_type: ControlTypes::Handshake(HandshakeControlInfo {
-                    syn_cookie: cookie,
-                    socket_id: local_sockid,
-                    info: HandshakeVSInfo::V5 {
-                        crypto_size: 0,
-                        ext_hs: None,
-                        ext_km: None,
-                        ext_config: None,
-                    },
-                    ..shake
-                }),
-            });
-
-            sock.send((resp_handshake.clone(), from)).await?;
-            debug!("Sending induction to {}", from);
-
-            return Ok((cookie, from, resp_handshake));
-        } else {
-            continue; // try again
-        };
-    }
-}
-
-async fn get_conclusion<
-    T: Stream<Item = Result<(Packet, SocketAddr), Error>>
-        + Sink<(Packet, SocketAddr), Error = Error>
-        + Unpin,
->(
-    sock: &mut T,
-    induction_hs: &Packet,
-    cookie: i32,
-    local_socket_id: SocketID,
-    tsbpd_latency: Duration,
-    from: &SocketAddr,
-) -> Result<(Duration, HandshakeControlInfo, Packet), Error> {
-    // https://tools.ietf.org/html/draft-gg-udt-03#page-10
-    // The server, when receiving a handshake packet and the correct cookie,
-    // compares the packet size and maximum window size with its own values
-    // and set its own values as the smaller ones. The result values are
-    // also sent back to the client by a response handshake packet, together
-    // with the server's version and initial sequence number. The server is
-    // ready for sending/receiving data right after this step is finished.
-    // However, it must send back response packet as long as it receives any
-    // further handshakes from the same client.
-
-    // first packet received, wait for response (with cookie)
-    loop {
-        match get_packet(sock).await? {
-            (
-                Packet::Control(ControlPacket {
-                    control_type: ControlTypes::Handshake(ref shake),
-                    timestamp,
-                    ..
-                }),
-                from_second,
-            ) if from_second == *from => {
-                if shake.shake_type == ShakeType::Induction {
-                    // it maybe missed our induction packet, so send it again
-                    sock.send((induction_hs.clone(), *from)).await?;
-                    continue;
-                } else if shake.shake_type != ShakeType::Conclusion {
-                    // discard
-                    info!(
-                        "Expected Conclusion (-1) packet, got {:?} ({}). Discarding handshake.",
-                        shake.shake_type, shake.shake_type as i32
-                    );
-                    continue;
-                }
-
-                // check that the cookie matches
-                if shake.syn_cookie != cookie {
-                    // wait for the next one
-                    warn!(
-                        "Received invalid cookie handshake from {:?}: {}, should be {}",
-                        from, shake.syn_cookie, cookie
-                    );
-                    continue;
-                }
-
-                if shake.info.version() != 5 {
-                    bail!("Conclusion was HSv4, not HSv5, terminating connection");
-                }
-
-                info!("Cookie was correct, connection established to {:?}", from);
-
-                let (srt_handshake, crypto_size) = if let HandshakeVSInfo::V5 {
-                    ext_hs: Some(SrtControlPacket::HandshakeRequest(hs)),
-                    crypto_size,
-                    ..
-                } = shake.info
-                {
-                    (hs, crypto_size)
-                } else {
-                    bail!("Did not get SRT handshake request in conclusion handshake packet, using latency from this end");
-                };
-
-                let latency = Duration::max(srt_handshake.latency, tsbpd_latency);
-
-                // construct a packet to send back
-                let resp_handshake = Packet::Control(ControlPacket {
-                    timestamp,
-                    dest_sockid: shake.socket_id,
-                    control_type: ControlTypes::Handshake(HandshakeControlInfo {
-                        syn_cookie: cookie,
-                        socket_id: local_socket_id,
-                        info: HandshakeVSInfo::V5 {
-                            ext_hs: Some(SrtControlPacket::HandshakeResponse(SrtHandshake {
-                                latency,
-                                ..srt_handshake
-                            })),
-                            ext_km: None,
-                            ext_config: None,
-                            crypto_size,
-                        },
-                        ..*shake
-                    }),
+            Err(e) => {
+                eprintln!("{:?}", e);
+            }
+            _ => {}
+        }
+        match listen.1.clone() {
+            Connected(resp_handshake, settings) => {
+                return Ok(Connection {
+                    settings,
+                    hs_returner: Box::new(move |_| Some(resp_handshake.clone())),
                 });
-
-                // send the packet
-                sock.send((resp_handshake.clone(), *from)).await?;
-
-                return Ok((latency, shake.clone(), resp_handshake));
             }
-            _ => continue,
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
I spent a half day and redesigned/refactored the client/server connection setup to use an explicit state machine (i.e. mealy machine) instead of an implicit compiler generated state machine via async/await. This allowed for the removal of all dependencies on IO in the bulk of the listen and connect code, there’s just one external loop with a pattern match on the outputs of the state machine. The state machines take SRT packets and timer ticks in and outputs packets to send or errors to log. All inputs are also matched against current state using a few match statements. This approach to implementing protocols is frequently used in languages with advanced pattern matching facilities and algebraic data types (e.g. Erlang & typed functional languages). This makes inputs and outputs and transitions explicit. This would enable extremely fast thorough isolation testing (unit, property, generative, fuzz, etc.). I also find it much easier to reason about stateful network protocols this way. The only edge I ran up against is that I can't match against a borrow and a move in the same match statement in Rust, which required me to do more cloning and reference counting than I wanted to. If this is worth keeping around I'll come back and fix this later.