### PR TITLE
Timestamp drift recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ futures = "0.3"
 log = { version = "0.4", default-features = false }
 rand = "0.7"
 url = { version = "=2.1.0", optional = true } # https://github.com/servo/rust-url/issues/581
-# openssl = "0.10.24"
 bytes = "0.5"
+streaming-stats = "0.2.3"
 
 [dependencies.env_logger]
 version = "0.7"
@@ -39,6 +39,7 @@ features = ["full"]
 hex = "0.4"
 rand_distr = "0.2"
 env_logger = { version = "0.7", default-features = false }
+proptest = "0.9.5"
 
 [lib]
 name = "srt"

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -20,7 +20,7 @@ impl TimeBase {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn timestamp_from(&self, instant: Instant) -> TimeStamp {
         if self.0 > instant {
-            0 - (self.0 - instant).as_micros() as i32
+            -((self.0 - instant).as_micros() as i32)
         } else {
             (instant - self.0).as_micros() as i32
         }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -7,27 +7,82 @@ pub mod sender;
 /// Timestamp in us
 pub type TimeStamp = i32;
 
+/// Duration in us, e.g. RTT
+pub type TimeSpan = i32;
+
 #[derive(Copy, Clone, Debug)]
 pub struct TimeBase(Instant);
 impl TimeBase {
-    pub fn new() -> Self {
-        Self(Instant::now())
-    }
-
-    pub fn from_raw(start_time: Instant) -> Self {
-        let _ = Self::new();
+    pub fn new(start_time: Instant) -> Self {
         Self(start_time)
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn timestamp_from(&self, instant: Instant) -> TimeStamp {
-        let elapsed = instant - self.0;
-        elapsed.as_micros() as i32 // TODO: handle overflow here
+        if self.0 > instant {
+            0 - (self.0 - instant).as_micros() as i32
+        } else {
+            (instant - self.0).as_micros() as i32
+        }
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn instant_from(&self, timestamp: TimeStamp) -> Instant {
-        self.0 + Duration::from_micros(timestamp as u64)
+        if timestamp < 0 {
+            self.0 - Duration::from_micros(timestamp.abs() as u64)
+        } else {
+            self.0 + Duration::from_micros(timestamp as u64)
+        }
+    }
+
+    pub fn adjust(&mut self, delta: TimeSpan) {
+        match delta {
+            delta if delta > 0 => {
+                self.0 += Duration::from_micros(delta as u64);
+            }
+            delta if delta < 0 => {
+                self.0 -= Duration::from_micros(delta.abs() as u64);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod timebase {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn timestamp_roundtrip(expected_ts: i32) {
+            let timebase = TimeBase::new(Instant::now());
+
+            let ts = timebase.timestamp_from(timebase.instant_from(expected_ts));
+            assert_eq!(ts, expected_ts);
+        }
+
+        #[test]
+        fn timestamp_from(expected_ts: i32, n in -10i64..10) {
+            let now = Instant::now();
+            let timebase = TimeBase::new(now);
+            let delta = ((std::i32::MAX as i64 + 1) * 2 * n as i64) + expected_ts as i64;
+            let instant = if delta > 0 { now + Duration::from_micros(delta as u64) } else { now - Duration::from_micros(delta.abs() as u64) };
+            let ts = timebase.timestamp_from(instant);
+            assert_eq!(ts, expected_ts);
+        }
+
+        #[test]
+        fn adjust(drift: i16) {
+            let now = Instant::now();
+            let mut timebase = TimeBase::new(now);
+
+            let original_ts = timebase.timestamp_from(now);
+            timebase.adjust(drift as TimeSpan);
+            let ts = timebase.timestamp_from(now);
+
+            assert_eq!(ts, original_ts - drift as TimeSpan);
+        }
     }
 }
 

--- a/src/protocol/receiver/mod.rs
+++ b/src/protocol/receiver/mod.rs
@@ -17,6 +17,8 @@ use crate::protocol::handshake::Handshake;
 use crate::{seq_number::seq_num_range, ConnectionSettings, SeqNumber};
 
 mod buffer;
+mod time;
+
 use buffer::RecvBuffer;
 
 #[derive(Debug, Clone)]
@@ -220,8 +222,9 @@ impl Receiver {
 
         match packet {
             Packet::Control(ctrl) => {
-                // handle the control packet
+                self.receive_buffer.synchronize_clock(now, ctrl.timestamp);
 
+                // handle the control packet
                 match ctrl.control_type {
                     ControlTypes::Ack { .. } => warn!("Receiver received ACK packet, unusual"),
                     ControlTypes::Ack2(seq_num) => self.handle_ack2(seq_num, now),

--- a/src/protocol/receiver/time.rs
+++ b/src/protocol/receiver/time.rs
@@ -1,0 +1,111 @@
+use std::time::{Duration, Instant};
+
+use stats::OnlineStats;
+
+use crate::protocol::{TimeBase, TimeSpan, TimeStamp};
+
+pub(crate) struct SynchronizedRemoteClock {
+    tolerance: Duration,
+    time_base: TimeBase,
+    stats: Option<OnlineStats>,
+}
+
+impl SynchronizedRemoteClock {
+    const MAX_SAMPLES: usize = 1_000;
+    const DRIFT_TOLERANCE: Duration = Duration::from_millis(5);
+
+    pub fn new(now: Instant) -> Self {
+        Self {
+            // TODO: Drift deviation tolerance should be parameterized.
+            //       It wasn't in the reference implementation, but I added it because the reference
+            //       implementation is susceptible to invalid clock adjustments during periods of
+            //       acute network latency
+            tolerance: Self::DRIFT_TOLERANCE,
+            time_base: TimeBase::new(now),
+            stats: None,
+        }
+    }
+
+    pub fn synchronize(&mut self, now: Instant, ts: TimeStamp) {
+        let drift = self.time_base.timestamp_from(now) - ts;
+        match &mut self.stats {
+            None => {
+                self.time_base.adjust(drift);
+            }
+            Some(stats) => {
+                stats.add(drift);
+
+                if stats.len() < Self::MAX_SAMPLES {
+                    return;
+                }
+
+                if stats.stddev() < self.tolerance.as_micros() as f64 {
+                    self.time_base.adjust(stats.mean() as TimeSpan);
+                }
+            }
+        }
+        self.stats = Some(OnlineStats::new());
+    }
+
+    pub fn instant_from(&self, ts: TimeStamp) -> Instant {
+        self.time_base.instant_from(ts)
+    }
+}
+
+#[cfg(test)]
+mod synchronized_remote_clock {
+    use std::time::Duration;
+
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn synchronize(drift_ts in 1u64..5000000) {
+            const MAX_SAMPLES: i32 = 1000;
+
+            let drift = Duration::from_micros(drift_ts);
+            let start = Instant::now();
+            let start_ts = 100_000_000 as TimeStamp;
+
+            let mut clock = SynchronizedRemoteClock::new(start);
+
+            clock.synchronize(start, start_ts);
+            let instant = clock.instant_from(start_ts);
+
+            assert_eq!(instant, start, "the clock should be adjusted on the first sample");
+
+            for tick_ts in 1..1002 {
+                let tick = Duration::from_micros(tick_ts as u64);
+                let now = start + tick + drift;
+                let now_ts = start_ts + tick_ts;
+
+                clock.synchronize(now, now_ts);
+                let instant = clock.instant_from(now_ts);
+
+                if tick_ts < MAX_SAMPLES {
+                    assert_eq!(instant, start + tick, "the clock should not be adjusted until {} samples: tick_ts = {}", MAX_SAMPLES, tick_ts);
+                }
+                else if tick_ts == MAX_SAMPLES {
+                    assert_eq!(instant, now, "the clock should be adjusted after {} samples", MAX_SAMPLES);
+                }
+                else {
+                    assert_eq!(instant, now, "the clock should not be adjusted until the next {} samples: tick_ts = {}", MAX_SAMPLES, tick_ts);
+                }
+            }
+
+            // simulate drift variance outside tolerance (+/- 5ms)
+            for tick_ts in 1002..2002 {
+                let tick = Duration::from_micros(tick_ts as u64);
+                let now = start + tick + drift;
+                let now_ts = start_ts + tick_ts;
+
+                clock.synchronize(now, now_ts - ((tick_ts % 2) * 11000)); // constant 5ms drift variance
+                let instant = clock.instant_from(now_ts);
+
+                assert_eq!(instant, now, "the clock should not be adjusted: tick_ts = {}", tick_ts);
+            }
+
+        }
+    }
+}

--- a/src/protocol/sender/buffers.rs
+++ b/src/protocol/sender/buffers.rs
@@ -27,7 +27,7 @@ impl TransmitBuffer {
         Self {
             remote_socket_id: settings.remote_sockid,
             max_packet_size: settings.max_packet_size as usize,
-            time_base: TimeBase::from_raw(settings.socket_start_time),
+            time_base: TimeBase::new(settings.socket_start_time),
             buffer: Default::default(),
             next_sequence_number: settings.init_seq_num,
             next_message_number: MsgNumber::new_truncate(0),
@@ -36,7 +36,7 @@ impl TransmitBuffer {
 
     /// In the case of a message longer than the packet size,
     /// It will be split into multiple packets
-    pub fn push_message(&mut self, data: (Instant, Bytes)) {
+    pub fn push_data(&mut self, data: (Instant, Bytes)) {
         let (time, mut payload) = data;
         let mut location = PacketLocation::FIRST;
         let message_number = self.get_new_message_number();
@@ -59,9 +59,24 @@ impl TransmitBuffer {
         }
     }
 
-    pub fn push_data(&mut self, data: (Bytes, Instant)) {
-        let (payload, time) = data;
-        self.push_message((time, payload));
+    pub fn pop_front(&mut self) -> Option<DataPacket> {
+        self.buffer.pop_front()
+    }
+
+    pub fn front(&self) -> Option<&DataPacket> {
+        self.buffer.front()
+    }
+
+    pub fn latest_seqence_number(&self) -> SeqNumber {
+        self.next_sequence_number - 1
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    pub fn timestamp_from(&self, at: Instant) -> TimeStamp {
+        self.time_base.timestamp_from(at)
     }
 
     fn begin_transmit(
@@ -85,18 +100,6 @@ impl TransmitBuffer {
         self.buffer.push_back(packet)
     }
 
-    pub fn pop_front(&mut self) -> Option<DataPacket> {
-        self.buffer.pop_front()
-    }
-
-    pub fn front(&self) -> Option<&DataPacket> {
-        self.buffer.front()
-    }
-
-    pub fn latest_seqence_number(&self) -> SeqNumber {
-        self.next_sequence_number - 1
-    }
-
     /// Gets the next available message number
     fn get_new_message_number(&mut self) -> MsgNumber {
         self.next_message_number += 1;
@@ -108,14 +111,6 @@ impl TransmitBuffer {
         // this does looping for us
         self.next_sequence_number += 1;
         self.next_sequence_number - 1
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.buffer.is_empty()
-    }
-
-    pub fn timestamp_from(&self, at: Instant) -> TimeStamp {
-        self.time_base.timestamp_from(at)
     }
 }
 

--- a/src/protocol/sender/buffers.rs
+++ b/src/protocol/sender/buffers.rs
@@ -36,7 +36,7 @@ impl TransmitBuffer {
 
     /// In the case of a message longer than the packet size,
     /// It will be split into multiple packets
-    pub fn push_data(&mut self, data: (Instant, Bytes)) {
+    pub fn push_message(&mut self, data: (Instant, Bytes)) {
         let (time, mut payload) = data;
         let mut location = PacketLocation::FIRST;
         let message_number = self.get_new_message_number();

--- a/src/protocol/sender/mod.rs
+++ b/src/protocol/sender/mod.rs
@@ -160,7 +160,7 @@ impl Sender {
     }
 
     pub fn handle_data(&mut self, data: (Instant, Bytes)) {
-        self.transmit_buffer.push_data(data);
+        self.transmit_buffer.push_message(data);
     }
 
     pub fn handle_snd_timer(&mut self, now: Instant) {

--- a/src/protocol/sender/mod.rs
+++ b/src/protocol/sender/mod.rs
@@ -160,8 +160,7 @@ impl Sender {
     }
 
     pub fn handle_data(&mut self, data: (Instant, Bytes)) {
-        let (t, b) = data;
-        self.transmit_buffer.push_data((b, t));
+        self.transmit_buffer.push_data(data);
     }
 
     pub fn handle_snd_timer(&mut self, now: Instant) {

--- a/tests/single_packet_tsbpd.rs
+++ b/tests/single_packet_tsbpd.rs
@@ -55,8 +55,15 @@ async fn single_packet_tsbpd() -> Result<(), Error> {
 
     assert_eq!(&packet, "Hello World!");
 
-    // the time from the packet should be close to `start`, less than 5ms
-    assert!(start - time < Duration::from_millis(5));
+    let expected_displacement = Duration::from_millis(1);
+    let displacement = if start > time {
+        start - time
+    } else {
+        time - start
+    };
+    assert!(displacement < expected_displacement,
+            "TsbPd time calculated for the packet should be close to `start` time\nExpected: < {:?}\nActual: {:?}\n",
+            expected_displacement, displacement);
 
     // the recvr should return None now
     assert!(recvr.next().await.is_none());


### PR DESCRIPTION
I took an initial pass at timestamp drift recovery. The clock only gets adjusted during stable network conditions. This is done by ensuring that drift deviation is within a hard coded tolerance (currently 5ms). This avoids abrupt and sometimes obtuse clock adjustments during periods of acute latency, e.g. due to network congestion. The reference implementation doesn't do this, but it should. I left a TODO to remind us to make the drift deviation tolerance configurable.