### PR TITLE
Fix connection setup failure for security reasons

### DIFF
--- a/srt-protocol/src/pending_connection.rs
+++ b/srt-protocol/src/pending_connection.rs
@@ -33,7 +33,6 @@ pub enum ConnectError {
 
 #[derive(Debug, Clone)]
 pub struct ConnInitSettings {
-    pub starting_send_seqnum: SeqNumber,
     pub local_sockid: SocketID,
     pub crypto: Option<CryptoOptions>,
     pub send_latency: Duration,
@@ -95,7 +94,6 @@ impl Default for ConnInitSettings {
             crypto: None,
             send_latency: Duration::from_millis(50),
             recv_latency: Duration::from_micros(50),
-            starting_send_seqnum: random(),
             local_sockid: random(),
         }
     }
@@ -106,7 +104,6 @@ impl ConnInitSettings {
             crypto: self.crypto.clone(),
             send_latency: self.send_latency,
             recv_latency: self.recv_latency,
-            starting_send_seqnum: random(),
             local_sockid: random(),
         }
     }

--- a/srt-protocol/src/pending_connection/hsv5.rs
+++ b/srt-protocol/src/pending_connection/hsv5.rs
@@ -6,7 +6,7 @@ use crate::{
     packet::{
         HandshakeControlInfo, HandshakeVSInfo, SrtControlPacket, SrtHandshake, SrtShakeFlags,
     },
-    ConnectionSettings, SrtVersion,
+    ConnectionSettings, SeqNumber, SrtVersion,
 };
 use std::{
     net::SocketAddr,
@@ -15,6 +15,7 @@ use std::{
 
 pub fn gen_hsv5_response(
     settings: ConnInitSettings,
+    init_send_seq_num: SeqNumber,
     with_hsv5: &HandshakeControlInfo,
     from: SocketAddr,
 ) -> Result<(HandshakeVSInfo, ConnectionSettings), ConnectError> {
@@ -74,7 +75,7 @@ pub fn gen_hsv5_response(
             remote_sockid: with_hsv5.socket_id,
             local_sockid: settings.local_sockid,
             socket_start_time: Instant::now(), // xxx?
-            init_send_seq_num: settings.starting_send_seqnum,
+            init_send_seq_num,
             init_recv_seq_num: with_hsv5.init_seq_num,
             max_packet_size: 1500, // todo: parameters!
             max_flow_size: 8192,
@@ -128,6 +129,7 @@ impl StartedInitiator {
     pub fn finish_hsv5_initiation(
         self,
         response: &HandshakeControlInfo,
+        init_send_seq_num: SeqNumber,
         from: SocketAddr,
     ) -> Result<ConnectionSettings, ConnectError> {
         // TODO: factor this out with above...
@@ -156,7 +158,7 @@ impl StartedInitiator {
             remote_sockid: response.socket_id,
             local_sockid: self.settings.local_sockid,
             socket_start_time: Instant::now(), // xxx?
-            init_send_seq_num: self.settings.starting_send_seqnum,
+            init_send_seq_num,
             init_recv_seq_num: response.init_seq_num,
             max_packet_size: 1500, // todo: parameters!
             max_flow_size: 8192,

--- a/srt-protocol/src/pending_connection/listen.rs
+++ b/srt-protocol/src/pending_connection/listen.rs
@@ -122,7 +122,8 @@ impl Listen {
                         syn_cookie: state.cookie,
                         socket_id: self.init_settings.local_sockid,
                         info: hsv5,
-                        init_seq_num: self.init_settings.starting_send_seqnum,
+                        // use peer's ISN and send it back for security check
+                        init_seq_num: shake.init_seq_num,
                         shake_type: ShakeType::Conclusion,
                         ..shake // TODO: this will pass peer wrong
                     }),

--- a/srt-protocol/src/pending_connection/listen.rs
+++ b/srt-protocol/src/pending_connection/listen.rs
@@ -69,7 +69,7 @@ impl Listen {
                             ext_km: None,
                             ext_config: None,
                         },
-                        init_seq_num: self.init_settings.starting_send_seqnum,
+                        init_seq_num: shake.init_seq_num,
                         ..shake
                     }),
                 });
@@ -112,8 +112,12 @@ impl Listen {
             // first induction received, wait for response (with cookie)
             (ShakeType::Conclusion, VERSION_5, syn_cookie) if syn_cookie == state.cookie => {
                 // construct a packet to send back
-                let (hsv5, connection) =
-                    gen_hsv5_response(self.init_settings.clone(), &shake, from)?;
+                let (hsv5, connection) = gen_hsv5_response(
+                    self.init_settings.clone(),
+                    shake.init_seq_num,
+                    &shake,
+                    from,
+                )?;
 
                 let resp_handshake = ControlPacket {
                     timestamp,

--- a/srt-protocol/src/pending_connection/listen.rs
+++ b/srt-protocol/src/pending_connection/listen.rs
@@ -122,7 +122,8 @@ impl Listen {
                         syn_cookie: state.cookie,
                         socket_id: self.init_settings.local_sockid,
                         info: hsv5,
-                        // srt/srtcore/core.cpp
+                        // in srt/srtcore/core.cpp
+                        //
                         // void CUDT::acceptAndRespond(...)
                         // {
                         //    ...

--- a/srt-protocol/src/pending_connection/listen.rs
+++ b/srt-protocol/src/pending_connection/listen.rs
@@ -122,7 +122,14 @@ impl Listen {
                         syn_cookie: state.cookie,
                         socket_id: self.init_settings.local_sockid,
                         info: hsv5,
-                        // use peer's ISN and send it back for security check
+                        // srt/srtcore/core.cpp
+                        // void CUDT::acceptAndRespond(...)
+                        // {
+                        //    ...
+                        //    // use peer's ISN and send it back for security check
+                        //    m_iISN = hs->m_iISN;
+                        //    ...
+                        // }
                         init_seq_num: shake.init_seq_num,
                         shake_type: ShakeType::Conclusion,
                         ..shake // TODO: this will pass peer wrong

--- a/srt-tokio/Cargo.toml
+++ b/srt-tokio/Cargo.toml
@@ -15,6 +15,7 @@ srt-protocol = { path = "../srt-protocol" }
 log = { version = "0.4", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 bytes = "0.5"
+rand = "0.7"
 
 [dependencies.tokio]
 version = "0.2"

--- a/srt-tokio/src/builder.rs
+++ b/srt-tokio/src/builder.rs
@@ -196,6 +196,7 @@ impl SrtSocketBuilder {
                     addr,
                     self.local_addr.ip(),
                     self.init_settings,
+                    rand::random(),
                 )
                 .await?
             }
@@ -205,6 +206,7 @@ impl SrtSocketBuilder {
                     self.local_addr,
                     remote_public,
                     self.init_settings,
+                    rand::random(),
                 )
                 .await?
             }

--- a/srt-tokio/src/pending_connection.rs
+++ b/srt-tokio/src/pending_connection.rs
@@ -15,7 +15,7 @@ use srt_protocol::{
         ConnInitSettings,
     },
     protocol::handshake::Handshake,
-    Connection, Packet, PacketParseError,
+    Connection, Packet, PacketParseError, SeqNumber,
 };
 
 use crate::util::get_packet;
@@ -28,13 +28,14 @@ pub async fn connect<T>(
     remote: SocketAddr,
     local_addr: IpAddr,
     init_settings: ConnInitSettings,
+    init_seq_number: SeqNumber,
 ) -> Result<Connection, io::Error>
 where
     T: Stream<Item = Result<(Packet, SocketAddr), PacketParseError>>
         + Sink<(Packet, SocketAddr), Error = io::Error>
         + Unpin,
 {
-    let mut connect = Connect::new(remote, local_addr, init_settings);
+    let mut connect = Connect::new(remote, local_addr, init_settings, init_seq_number);
 
     let mut tick_interval = interval(Duration::from_millis(100));
     loop {
@@ -95,6 +96,7 @@ pub async fn rendezvous<T>(
     local_addr: SocketAddr,
     remote_public: SocketAddr,
     init_settings: ConnInitSettings,
+    init_seq_number: SeqNumber,
 ) -> Result<Connection, io::Error>
 where
     T: Stream<Item = Result<(Packet, SocketAddr), PacketParseError>>
@@ -102,7 +104,7 @@ where
         + Unpin,
 {
     let sockid = init_settings.local_sockid;
-    let mut rendezvous = Rendezvous::new(local_addr, remote_public, init_settings);
+    let mut rendezvous = Rendezvous::new(local_addr, remote_public, init_settings, init_seq_number);
 
     let mut tick_interval = interval(Duration::from_millis(100));
     loop {


### PR DESCRIPTION
The client of the reference implementation cannot be connected to your implementation.
```
$ test-c-client 127.0.0.1 3333
srt startup
srt socket
srt remote address
srt setsockflag
srt connect
srt_connect: Connection setup failure: abort for security reasons
```

I think that the listener should use peer's ISN and send it back for security check.