### PR TITLE
Fix parsing & encoding of stream id and expose it

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
+#[target.x86_64-unknown-linux-gnu]
+#rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-#[target.x86_64-unknown-linux-gnu]
-#rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]

--- a/srt-protocol/src/pending_connection/hsv5.rs
+++ b/srt-protocol/src/pending_connection/hsv5.rs
@@ -52,6 +52,12 @@ pub fn gen_hsv5_response(
         None
     };
 
+    let sid = if let HandshakeVSInfo::V5(info) = &with_hsv5.info {
+        info.sid.clone()
+    } else {
+        None
+    };
+
     Ok((
         HandshakeVSInfo::V5(HSV5Info {
             crypto_size: cm.as_ref().map(|c| c.key_length()).unwrap_or(0),
@@ -62,7 +68,7 @@ pub fn gen_hsv5_response(
                 recv_latency: settings.recv_latency,
             })),
             ext_km: outgoing_ext_km.map(SrtControlPacket::KeyManagerResponse),
-            sid: None,
+            sid,
         }),
         ConnectionSettings {
             remote: from,


### PR DESCRIPTION
The parsing and serialization of the stream id was not converting it to and from big-endian 4-byte-words.

It was also not properly set on the handshake response for a `Connection`.

Related #65 