### PR TITLE
Remove the custom linking options

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]


### PR DESCRIPTION
Some systems do not have clang or a modern enough version of it.