### PR TITLE
transmit: Add SIGINT shutdown hook

### DIFF
--- a/srt-transmit/Cargo.toml
+++ b/srt-transmit/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "1.0"
 anyhow = "1"
 pretty_env_logger = { version = "0.4", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+signal-hook = "0.3.12"
 
 [dependencies.tokio]
 version = "1"

--- a/srt-transmit/src/main.rs
+++ b/srt-transmit/src/main.rs
@@ -24,7 +24,6 @@ use futures::{
     prelude::*,
     ready,
     stream::{self, once, unfold, BoxStream},
-    try_join,
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt},
@@ -33,6 +32,7 @@ use tokio::{
     net::UdpSocket,
     time::interval,
     select,
+    try_join,
 };
 use tokio_util::{codec::BytesCodec, codec::Framed, codec::FramedWrite, udp::UdpFramed};
 


### PR DESCRIPTION
Hi all,

This PR is in relation to: https://github.com/russelltg/srt-rs/issues/112

A pretty simple addition; we periodically (every 500ms) check if the SIGINT flag has been set and break out of the piping loop if so (and thus the sinks are shutdown/closed).
Also slightly refactors the loop to be a bit more readable in the select! macro context.