### PR TITLE
transmit: Add SIGINT shutdown hook (re)

### DIFF
--- a/srt-transmit/Cargo.toml
+++ b/srt-transmit/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "1.0"
 anyhow = "1"
 pretty_env_logger = { version = "0.4", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+signal-hook = "0.3.12"
 
 [dependencies.tokio]
 version = "1"
@@ -33,6 +34,7 @@ features = ["full"]
 [dev-dependencies]
 rand = "0.8"
 tokio-stream = "0.1"
+nix = "0.23"
 
 [features]
 default = []

--- a/srt-transmit/tests/timeout.rs
+++ b/srt-transmit/tests/timeout.rs
@@ -1,5 +1,11 @@
 use std::{env, path::PathBuf, process::Stdio, time::Instant};
 
+#[cfg(not(windows))]
+use nix::{
+    sys::signal::{kill, Signal},
+    unistd::Pid,
+};
+
 use bytes::Bytes;
 use futures::prelude::*;
 use tokio::{
@@ -107,5 +113,78 @@ async fn sender_timeout() {
 
         a.kill().await.unwrap();
     };
+    futures::join!(sender, recvr);
+}
+
+// There doesn't seem to exist any crates for programmatically sending Ctrl+C events to a child process on Windows
+// within Rust. One avenue to explore would be the raw winapi binding - GenerateConsoleCtrlEvent.
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn sigint_termination_idle() {
+    let _ = pretty_env_logger::try_init();
+    
+    let stranmsit_rs = find_stransmit_rs();
+    let mut a = Command::new(&stranmsit_rs)
+        .args(&["-", "-"])
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+        
+    sleep(Duration::from_millis(500)).await;
+    let pid = Pid::from_raw(a.id().unwrap() as i32);
+    kill(pid, Signal::SIGINT).unwrap();
+
+    let out = a.wait().await.unwrap();
+    assert_eq!(out.code().unwrap(), 130);
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn sigint_termination_work() {
+    let _ = pretty_env_logger::try_init();
+
+    let b = SrtSocket::builder().listen_on(1880);
+
+    let stranmsit_rs = find_stransmit_rs();
+    let mut a = Command::new(&stranmsit_rs)
+        .args(&["srt://localhost:1880", "-"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let sender = async move {
+        let mut b = b.await.unwrap();
+
+        let mut got_done = false;
+        for _ in 0..200 {
+            if b.send((Instant::now(), Bytes::from_static(b"asdf\n")))
+                .await
+                .is_err()
+            {
+                got_done = true;
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+        assert!(got_done);
+    };
+
+    let recvr = async move {
+        let mut out = BufReader::new(a.stdout.as_mut().unwrap());
+        let mut line = String::new();
+
+        for _ in 0..10 {
+            out.read_line(&mut line).await.unwrap();
+        }
+
+        let pid = Pid::from_raw(a.id().unwrap() as i32);
+        kill(pid, Signal::SIGINT).unwrap();
+
+        let out = a.wait().await.unwrap();
+        assert_eq!(out.code().unwrap(), 130);
+    };
+
     futures::join!(sender, recvr);
 }


### PR DESCRIPTION
Hi all (again ;)),

This PR is in relation to https://github.com/russelltg/srt-rs/issues/112 and adds:
- A ZST error type representing a user interrupt error so that we can return a non 0/1 exit code.
- The actual SIGINT handling and termination with an exit code of 130.
- Unit tests for terminating an idle transmit (stdin, stdout) and where the transmit is doing actual work.

As was noted in https://github.com/russelltg/srt-rs/pull/131 's code comments, there doesn't seem to exist any crate for programmatically sending Ctrl+C events on Windows which I've added a comment about. There's a chance this could be handled via a raw winapi binding but I don't have access to a Windows machine currently to test. I'll look into it in the future if no one else has by then.
