### PR TITLE
enforce lower bound on statistics interval

### DIFF
--- a/srt-protocol/src/options/error.rs
+++ b/srt-protocol/src/options/error.rs
@@ -1,4 +1,4 @@
-use std::{io, io::ErrorKind, net::IpAddr};
+use std::{io, io::ErrorKind, net::IpAddr, time::Duration};
 
 use thiserror::Error;
 
@@ -61,6 +61,9 @@ pub enum OptionsError {
 
     #[error("IP TTL is invalid, must be > 0")]
     InvalidIpTtl,
+
+    #[error("Statistics interval is out of range: {0:?}. The minimum interval is 200ms.")]
+    StatisticsIntervalOutOfRange(Duration),
 }
 
 impl From<OptionsError> for io::Error {

--- a/srt-protocol/src/options/session.rs
+++ b/srt-protocol/src/options/session.rs
@@ -45,6 +45,8 @@ impl Validation for Session {
         use OptionsError::*;
         if self.max_segment_size > PacketSize(1500) {
             Err(MaxSegmentSizeOutOfRange(self.max_segment_size))
+        } else if self.statistics_interval < Duration::from_millis(200) {
+            Err(StatisticsIntervalOutOfRange(self.statistics_interval))
         } else {
             Ok(())
         }


### PR DESCRIPTION
make sure performance isn't impacted by errant statistics interval configuration, see #166