### PR TITLE
Add dependabot configuration 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #184.

Have to activate version/security update for the repo (cf. https://docs.github.com/fr/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates).
![image](https://user-images.githubusercontent.com/7780173/222981840-5f22911d-127d-4aec-9ad2-8cac4c40a4d9.png)
