### PR TITLE
Fix: use more robust dns resolution

### DIFF
--- a/srt-tokio/Cargo.toml
+++ b/srt-tokio/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.4.1"
 bytes = "1"
 rand = "0.8"
 socket2 = "0.5"
+trust-dns-resolver = "0.22.0"
 
 [dependencies.ac-ffmpeg]
 optional = true

--- a/srt-tokio/src/net.rs
+++ b/srt-tokio/src/net.rs
@@ -150,3 +150,22 @@ impl Display for PacketStreamClosedError {
 }
 
 impl error::Error for PacketStreamClosedError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[tokio::test]
+    async fn resolve_dns() {
+        let socket_address = SocketAddress {
+            host: SocketHost::Domain("localhost".to_string()),
+            port: 3000,
+        };
+        let remote_host = lookup_remote_host(&socket_address).await.unwrap();
+        assert_eq!(
+            remote_host,
+            SocketAddr::new(V4(Ipv4Addr::new(127, 0, 0, 1)), 3000)
+        );
+    }
+}


### PR DESCRIPTION
Closes #201.

Using [trust_dns_resolver crate](https://docs.rs/trust-dns-resolver/latest/trust_dns_resolver/index.html) and applying OS's configuration for DNS resolution.

It is resolving now:
`INFO  srt_media::source::srt_source > Opening source: srt://google.com:3001
 DEBUG srt_tokio::socket::call       > None:connect - SendPacket(({HS Induction from=SRT#74F897B9 UDT: Datagram ts=00:00.000000 dst=SRT#00000000}, 216.58.214.174:3001))`