### PR TITLE
Add AsyncRead and AsyncWrite Implementation

### DIFF
--- a/srt-tokio/src/socket/mod.rs
+++ b/srt-tokio/src/socket/mod.rs
@@ -100,7 +100,7 @@ impl SrtSocket {
     }
 
     pub async fn close_and_finish(&mut self) -> Result<(), io::Error> {
-        futures::SinkExt::close(self).await?;
+        self.close().await?;
         (&mut self.task).await?;
         Ok(())
     }


### PR DESCRIPTION
Perhaps there's a reason for not doing this that I'm unaware of, but for my particular use-case it would be nice to have `SrtSocket` implement `AsyncRead` and `AsyncWrite`. Thanks for all the work on this library and let me know if there's another preferred method!