### PR TITLE
srt-tokio: remove `trust-dns-resolver` dependency

### DIFF
--- a/srt-tokio/Cargo.toml
+++ b/srt-tokio/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.4.1"
 bytes = "1"
 rand = "0.8"
 socket2 = "0.5"
-trust-dns-resolver = "0.22.0"
 
 [dependencies.ac-ffmpeg]
 optional = true


### PR DESCRIPTION
Without `trust-dns-resolver` a boatload of dependencies are removed from the project:

* `data-encoding`, `enum-as-inner`, `heck`, `hostname`, `ipconfig`, `ipnet`, `linked-hash-map`, `lock_api`, `lru-cache`, `match_cfg`, `matches`, `parking_lot`, `resolv-conf`, `scopeguard`, `trust-dns-proto`, `trust-dns-resolver`, `widestring`, `winreg`

If the user wants to use DNS-over-TLS, they can either lookup the name themself and supply a `SocketAddr` instead of a domain name, or they can set up their system resolver to use DNS-over-TLS.

This PR effectly reverts <https://github.com/russelltg/srt-rs/pull/202>, but fixes the bug in <https://github.com/russelltg/srt-rs/issues/201> instead. The problem was actually that Tokio's `lookup_host()` resolves to a `SocketAddr` instead of an `IpAddr`, so its argument needs a domain name and a port, not only a domain name.