### PR TITLE
Feat: drop too late packets option

### DIFF
--- a/srt-c/src/c_api.rs
+++ b/srt-c/src/c_api.rs
@@ -684,7 +684,7 @@ pub extern "C" fn srt_accept(
         Ok((sock, remote)) => {
             if let Some((addr, len)) = addr {
                 let osa = OsSocketAddr::from(remote);
-                *addr = unsafe { *(osa.as_ptr() as *const libc::sockaddr) };
+                *addr = unsafe { *(osa.as_ptr()) };
                 *len = osa.len() as c_int;
             }
             sock

--- a/srt-c/src/socket.rs
+++ b/srt-c/src/socket.rs
@@ -434,7 +434,7 @@ impl SocketData {
                                 opts.listen_cb_opaque,
                                 new_sock,
                                 5,
-                                OsSocketAddr::from(req.remote()).as_ptr() as *const libc::sockaddr,
+                                OsSocketAddr::from(req.remote()).as_ptr(),
                                 streamid_ptr,
                                 &mut ret,
                             )

--- a/srt-protocol/src/connection/mod.rs
+++ b/srt-protocol/src/connection/mod.rs
@@ -62,6 +62,11 @@ pub struct ConnectionSettings {
     pub send_tsbpd_latency: Duration,
     pub recv_tsbpd_latency: Duration,
 
+    /// The Too-Late Packet Drop (TLPKTDROP) mechanism allows the sender to
+    /// drop packets that have no chance to be delivered in time, and allows
+    /// the receiver to skip missing packets that have not been delivered in time
+    pub too_late_packet_drop: bool,
+
     pub peer_idle_timeout: Duration,
 
     /// Size of the receive buffer, in packets
@@ -484,6 +489,7 @@ mod duplex_connection {
                 bandwidth: LiveBandwidthMode::Unlimited,
                 statistics_interval: Duration::from_secs(10),
                 peer_idle_timeout: Duration::from_secs(5),
+                too_late_packet_drop: true,
             },
             handshake: crate::protocol::handshake::Handshake::Connector,
         }

--- a/srt-protocol/src/protocol/pending_connection/connect.rs
+++ b/srt-protocol/src/protocol/pending_connection/connect.rs
@@ -302,6 +302,7 @@ mod test {
                 max_packet_size: options::PacketSize(1500),
                 max_flow_size: options::PacketCount(8192),
                 peer_idle_timeout: Duration::from_secs(5),
+                too_late_packet_drop: true,
             },
             sid,
             random(),

--- a/srt-protocol/src/protocol/pending_connection/hsv5.rs
+++ b/srt-protocol/src/protocol/pending_connection/hsv5.rs
@@ -140,6 +140,7 @@ pub fn gen_access_control_response(
             send_buffer_size: settings.send_buffer_size,
             statistics_interval: settings.statistics_interval,
             peer_idle_timeout: settings.peer_idle_timeout,
+            too_late_packet_drop: settings.too_late_packet_drop,
         },
     )
 }
@@ -240,6 +241,7 @@ impl StartedInitiator {
             send_buffer_size: self.settings.send_buffer_size,
             statistics_interval: self.settings.statistics_interval,
             peer_idle_timeout: self.settings.peer_idle_timeout,
+            too_late_packet_drop: self.settings.too_late_packet_drop,
         })
     }
 }

--- a/srt-protocol/src/protocol/receiver/arq.rs
+++ b/srt-protocol/src/protocol/receiver/arq.rs
@@ -174,6 +174,7 @@ impl AutomaticRepeatRequestAlgorithm {
     pub fn new(
         socket_start_time: Instant,
         tsbpd_latency: Duration,
+        too_late_packet_drop: bool,
         init_seq_num: SeqNumber,
         buffer_size_packets: PacketCount,
     ) -> Self {
@@ -183,6 +184,7 @@ impl AutomaticRepeatRequestAlgorithm {
             receive_buffer: ReceiveBuffer::new(
                 socket_start_time,
                 tsbpd_latency,
+                too_late_packet_drop,
                 init_seq_num,
                 buffer_size_packets,
             ),
@@ -353,6 +355,7 @@ mod automatic_repeat_request_algorithm {
         let mut arq = AutomaticRepeatRequestAlgorithm::new(
             start,
             Duration::from_secs(2),
+            true,
             init_seq_num,
             PacketCount(8192),
         );
@@ -410,6 +413,7 @@ mod automatic_repeat_request_algorithm {
         let mut arq = AutomaticRepeatRequestAlgorithm::new(
             start,
             Duration::from_secs(2),
+            true,
             init_seq_num,
             PacketCount(8192),
         );
@@ -478,6 +482,7 @@ mod automatic_repeat_request_algorithm {
         let mut arq = AutomaticRepeatRequestAlgorithm::new(
             start,
             Duration::from_secs(2),
+            true,
             init_seq_num,
             PacketCount(8192),
         );
@@ -520,6 +525,7 @@ mod automatic_repeat_request_algorithm {
         let mut arq = AutomaticRepeatRequestAlgorithm::new(
             start,
             Duration::from_secs(1),
+            true,
             init_seq_num,
             PacketCount(8192),
         );
@@ -571,6 +577,7 @@ mod automatic_repeat_request_algorithm {
         let mut arq = AutomaticRepeatRequestAlgorithm::new(
             start,
             tsbpd_latency,
+            true,
             init_seq_num,
             PacketCount(8192),
         );

--- a/srt-protocol/src/protocol/receiver/buffer.rs
+++ b/srt-protocol/src/protocol/receiver/buffer.rs
@@ -459,7 +459,7 @@ impl ReceiveBuffer {
         &mut self,
         now: Instant,
     ) -> Result<Option<(Instant, Bytes)>, MessageError> {
-        if self.too_late_packet_drop {
+        if !self.too_late_packet_drop {
             return Ok(None);
         }
 

--- a/srt-protocol/src/protocol/receiver/mod.rs
+++ b/srt-protocol/src/protocol/receiver/mod.rs
@@ -71,6 +71,7 @@ impl Receiver {
             arq: AutomaticRepeatRequestAlgorithm::new(
                 settings.socket_start_time,
                 settings.recv_tsbpd_latency,
+                settings.too_late_packet_drop,
                 settings.init_seq_num,
                 settings.recv_buffer_size,
             ),

--- a/srt-protocol/src/protocol/sender/buffer.rs
+++ b/srt-protocol/src/protocol/sender/buffer.rs
@@ -595,6 +595,7 @@ mod test {
             send_buffer_size: PacketCount(8196),
             statistics_interval: Duration::from_secs(10),
             peer_idle_timeout: Duration::from_secs(5),
+            too_late_packet_drop: true,
         }
     }
 

--- a/srt-protocol/src/settings/connection.rs
+++ b/srt-protocol/src/settings/connection.rs
@@ -16,7 +16,7 @@ pub struct ConnInitSettings {
     pub peer_idle_timeout: Duration,
     pub bandwidth: options::LiveBandwidthMode,
     pub statistics_interval: Duration,
-
+    pub too_late_packet_drop: bool,
     /// Receive buffer size in packets
     pub recv_buffer_size: options::PacketCount,
     /// Size of the send buffer, in packets
@@ -68,6 +68,7 @@ impl From<options::SocketOptions> for ConnInitSettings {
                 / (options.session.max_segment_size - Packet::HEADER_SIZE),
             max_packet_size: options.sender.max_payload_size,
             max_flow_size: options.sender.flow_control_window_size,
+            too_late_packet_drop: options.receiver.too_late_packet_drop,
         }
     }
 }

--- a/srt-protocol/tests/simulator/mod.rs
+++ b/srt-protocol/tests/simulator/mod.rs
@@ -215,6 +215,7 @@ impl RandomLossSimulation {
             send_buffer_size: PacketCount(8192),
             statistics_interval: Duration::from_secs(1),
             peer_idle_timeout: Duration::from_secs(5),
+            too_late_packet_drop: true,
         }
     }
 }

--- a/srt-protocol/tests/timestamp_rollover.rs
+++ b/srt-protocol/tests/timestamp_rollover.rs
@@ -47,6 +47,7 @@ fn timestamp_rollover() {
         send_buffer_size: PacketCount(8192),
         statistics_interval: Duration::from_secs(1),
         peer_idle_timeout: Duration::from_secs(5),
+        too_late_packet_drop: true,
     };
 
     let s2 = ConnectionSettings {
@@ -68,6 +69,7 @@ fn timestamp_rollover() {
         send_buffer_size: PacketCount(8192),
         statistics_interval: Duration::from_secs(1),
         peer_idle_timeout: Duration::from_secs(5),
+        too_late_packet_drop: true,
     };
 
     const PACKET_RATE: u32 = 10; // 10 packet/s


### PR DESCRIPTION
Referred in #166.

Implemented too late packets drop disabling through socket options configuration.