### PR TITLE
Expose the caller's specifed key size in ConnectionRequest

### DIFF
--- a/srt-protocol/src/protocol/pending_connection/listen.rs
+++ b/srt-protocol/src/protocol/pending_connection/listen.rs
@@ -611,6 +611,6 @@ mod test {
             panic!("expected a ConnectionResult::RequestAccess");
         };
 
-        assert_eq!(request_access.key_size, send_key_size);
+        assert_eq!(request_access.key_size, hs_key_size);
     }
 }

--- a/srt-protocol/src/protocol/pending_connection/listen.rs
+++ b/srt-protocol/src/protocol/pending_connection/listen.rs
@@ -581,11 +581,11 @@ mod test {
             Ok((build_hs_pack(test_induction()), conn_addr())),
         );
 
-        let send_key_size = KeySize::AES256;
+        let hs_key_size = KeySize::AES256;
 
         let shake = HandshakeControlInfo {
             info: HandshakeVsInfo::V5(HsV5Info {
-                key_size: send_key_size,
+                key_size: hs_key_size,
                 ext_hs: Some(SrtControlPacket::HandshakeRequest(SrtHandshake {
                     version: SrtVersion::CURRENT,
                     flags: SrtShakeFlags::SUPPORTED,

--- a/srt-protocol/src/protocol/pending_connection/listen.rs
+++ b/srt-protocol/src/protocol/pending_connection/listen.rs
@@ -237,7 +237,7 @@ impl Listen {
         // TODO: handle StreamId parsing error
         let stream_id = incoming.sid.clone().and_then(|s| s.try_into().ok());
         let remote_socket_id = shake.socket_id;
-        let key_size = incoming.key_size.clone();
+        let key_size = incoming.key_size;
 
         self.state = AccessControlRequested(state, timestamp, shake, incoming);
 

--- a/srt-protocol/src/protocol/pending_connection/listen.rs
+++ b/srt-protocol/src/protocol/pending_connection/listen.rs
@@ -571,4 +571,46 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn advertise_key_size() {
+        let mut l = Listen::new(ConnInitSettings::default(), true);
+
+        l.handle_packet(
+            Instant::now(),
+            Ok((build_hs_pack(test_induction()), conn_addr())),
+        );
+
+        let send_key_size = KeySize::AES256;
+
+        let shake = HandshakeControlInfo {
+            info: HandshakeVsInfo::V5(HsV5Info {
+                key_size: send_key_size,
+                ext_hs: Some(SrtControlPacket::HandshakeRequest(SrtHandshake {
+                    version: SrtVersion::CURRENT,
+                    flags: SrtShakeFlags::SUPPORTED,
+                    send_latency: Duration::from_secs(1),
+                    recv_latency: Duration::from_secs(2),
+                })),
+                ext_km: None,
+                ext_group: None,
+                sid: None,
+            }),
+            ..test_conclusion()
+        };
+
+        let hs_packet = Packet::Control(ControlPacket {
+            timestamp: TimeStamp::from_micros(0),
+            dest_sockid: random(),
+            control_type: ControlTypes::Handshake(shake),
+        });
+
+        let RequestAccess(request_access) =
+            l.handle_packet(Instant::now(), Ok((hs_packet, conn_addr())))
+        else {
+            panic!("expected a ConnectionResult::RequestAccess");
+        };
+
+        assert_eq!(request_access.key_size, send_key_size);
+    }
 }

--- a/srt-protocol/src/protocol/pending_connection/listen.rs
+++ b/srt-protocol/src/protocol/pending_connection/listen.rs
@@ -237,6 +237,7 @@ impl Listen {
         // TODO: handle StreamId parsing error
         let stream_id = incoming.sid.clone().and_then(|s| s.try_into().ok());
         let remote_socket_id = shake.socket_id;
+        let key_size = incoming.key_size.clone();
 
         self.state = AccessControlRequested(state, timestamp, shake, incoming);
 
@@ -245,6 +246,7 @@ impl Listen {
             remote,
             remote_socket_id,
             stream_id,
+            key_size,
         })
     }
 

--- a/srt-protocol/src/protocol/pending_connection/mod.rs
+++ b/srt-protocol/src/protocol/pending_connection/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod cookie;
 
 use std::{error::Error, fmt, io, net::SocketAddr};
 
+use crate::options::KeySize;
 use crate::{connection::Connection, options::StreamId, packet::*, settings::KeySettings};
 
 #[non_exhaustive]
@@ -38,6 +39,7 @@ pub struct AccessControlRequest {
     pub remote: SocketAddr,
     pub remote_socket_id: SocketId,
     pub stream_id: Option<StreamId>,
+    pub key_size: KeySize,
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/srt-tokio/examples/multiplex_authenticating_server.rs
+++ b/srt-tokio/examples/multiplex_authenticating_server.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 async fn main() -> io::Result<()> {
     let _ = pretty_env_logger::try_init();
 
-    let (_server, mut incoming) = SrtListener::builder().bind(333).await.unwrap();
+    let (_server, mut incoming) = SrtListener::builder().bind(3333).await.unwrap();
 
     while let Some(request) = incoming.incoming().next().await {
         tokio::spawn(async move { handle_request(request).await });
@@ -40,7 +40,7 @@ async fn handle_request(request: ConnectionRequest) {
     };
     let mut sender = request.accept(Some(key_settings)).await.unwrap();
     let mut stream = stream::iter(
-        Some(Ok((Instant::now(), Bytes::from("Hello authorized user!!")))).into_iter(),
+        Some(Ok((Instant::now(), Bytes::from("Hello authenticated user!!")))).into_iter(),
     );
 
     sender.send_all(&mut stream).await.unwrap();

--- a/srt-tokio/examples/multiplex_authenticating_server.rs
+++ b/srt-tokio/examples/multiplex_authenticating_server.rs
@@ -36,7 +36,7 @@ async fn handle_request(request: ConnectionRequest) {
 
     let key_settings = KeySettings {
         key_size: KeySize::AES256,
-        passphrase: Passphrase::try_from("password128").unwrap(),
+        passphrase: Passphrase::from("password128"),
     };
     let mut sender = request.accept(Some(key_settings)).await.unwrap();
     let mut stream = stream::iter(

--- a/srt-tokio/examples/multiplex_authenticating_server.rs
+++ b/srt-tokio/examples/multiplex_authenticating_server.rs
@@ -40,7 +40,11 @@ async fn handle_request(request: ConnectionRequest) {
     };
     let mut sender = request.accept(Some(key_settings)).await.unwrap();
     let mut stream = stream::iter(
-        Some(Ok((Instant::now(), Bytes::from("Hello authenticated user!!")))).into_iter(),
+        Some(Ok((
+            Instant::now(),
+            Bytes::from("Hello authenticated user!!"),
+        )))
+        .into_iter(),
     );
 
     sender.send_all(&mut stream).await.unwrap();

--- a/srt-tokio/examples/multiplex_authorizing_server.rs
+++ b/srt-tokio/examples/multiplex_authorizing_server.rs
@@ -1,0 +1,49 @@
+use bytes::Bytes;
+use futures::{stream, SinkExt, StreamExt};
+use log::info;
+use srt_protocol::access::RejectReason;
+use srt_protocol::options::KeySize;
+use srt_protocol::packet::ServerRejectReason;
+use srt_protocol::settings::{KeySettings, Passphrase};
+use srt_tokio::{ConnectionRequest, SrtListener};
+use std::io;
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let _ = pretty_env_logger::try_init();
+
+    let (_server, mut incoming) = SrtListener::builder().bind(3333).await.unwrap();
+
+    while let Some(request) = incoming.incoming().next().await {
+        tokio::spawn(async move { handle_request(request).await });
+    }
+
+    Ok(())
+}
+
+async fn handle_request(request: ConnectionRequest) {
+    info!("received connection request");
+
+    if *request.key_size() != KeySize::AES256 {
+        info!("rejecting, key size is not AES256");
+        request
+            .reject(RejectReason::Server(ServerRejectReason::BadRequest))
+            .await
+            .unwrap();
+        return;
+    }
+
+    let key_settings = KeySettings {
+        key_size: KeySize::AES256,
+        passphrase: Passphrase::try_from("password128").unwrap(),
+    };
+    let mut sender = request.accept(Some(key_settings)).await.unwrap();
+    let mut stream = stream::iter(
+        Some(Ok((Instant::now(), Bytes::from("Hello authorized user!!")))).into_iter(),
+    );
+
+    sender.send_all(&mut stream).await.unwrap();
+    sender.close().await.unwrap();
+    info!("finished sending bytes to caller");
+}

--- a/srt-tokio/examples/multiplex_authorizing_server.rs
+++ b/srt-tokio/examples/multiplex_authorizing_server.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 async fn main() -> io::Result<()> {
     let _ = pretty_env_logger::try_init();
 
-    let (_server, mut incoming) = SrtListener::builder().bind(3333).await.unwrap();
+    let (_server, mut incoming) = SrtListener::builder().bind(333).await.unwrap();
 
     while let Some(request) = incoming.incoming().next().await {
         tokio::spawn(async move { handle_request(request).await });
@@ -25,7 +25,7 @@ async fn main() -> io::Result<()> {
 async fn handle_request(request: ConnectionRequest) {
     info!("received connection request");
 
-    if *request.key_size() != KeySize::AES256 {
+    if request.key_size() != KeySize::AES256 {
         info!("rejecting, key size is not AES256");
         request
             .reject(RejectReason::Server(ServerRejectReason::BadRequest))

--- a/srt-tokio/src/listener/session.rs
+++ b/srt-tokio/src/listener/session.rs
@@ -40,8 +40,8 @@ impl ConnectionRequest {
     pub fn stream_id(&self) -> Option<&StreamId> {
         self.request.stream_id.as_ref()
     }
-    pub fn key_size(&self) -> &KeySize {
-        &self.request.key_size
+    pub fn key_size(&self) -> KeySize {
+        self.request.key_size
     }
 
     pub async fn accept(

--- a/srt-tokio/src/listener/session.rs
+++ b/srt-tokio/src/listener/session.rs
@@ -40,6 +40,9 @@ impl ConnectionRequest {
     pub fn stream_id(&self) -> Option<&StreamId> {
         self.request.stream_id.as_ref()
     }
+    pub fn key_size(&self) -> &KeySize {
+        &self.request.key_size
+    }
 
     pub async fn accept(
         self,

--- a/srt-tokio/tests/accesscontrol.rs
+++ b/srt-tokio/tests/accesscontrol.rs
@@ -79,8 +79,7 @@ async fn streamid() -> io::Result<()> {
             let stream_id = AccessControlList(vec![
                 StandardAccessControlEntry::UserName("russell".into()).into(),
                 StandardAccessControlEntry::ResourceName(format!("{i}")).into(),
-            ])
-                .to_string();
+            ]).to_string();
 
             let recvr = SrtSocket::builder()
                 .call("127.0.0.1:2000", Some(stream_id.as_str()))

--- a/srt-tokio/tests/accesscontrol.rs
+++ b/srt-tokio/tests/accesscontrol.rs
@@ -189,8 +189,8 @@ async fn key_size() {
 
     let listener = tokio::spawn(async move {
         while let Some(request) = incoming.incoming().next().await {
+            let key_size = request.key_size();
             let passphrase = request.stream_id().unwrap().as_str().into();
-            let key_size = request.key_size().clone();
 
             if let Ok(mut sender) = request
                 .accept(Some(KeySettings {

--- a/srt-tokio/tests/accesscontrol.rs
+++ b/srt-tokio/tests/accesscontrol.rs
@@ -1,7 +1,4 @@
-use std::{
-    io,
-    time::Instant,
-};
+use std::{io, time::Instant};
 
 use assert_matches::assert_matches;
 use bytes::Bytes;
@@ -181,6 +178,49 @@ async fn set_password() {
             CoreRejectReason::BadSecret.into()
         )))
     );
+
+    server.close().await;
+    listener.await.unwrap();
+}
+
+#[tokio::test]
+async fn key_size() {
+    let (mut server, mut incoming) = SrtListener::builder().bind(2001).await.unwrap();
+
+    let listener = tokio::spawn(async move {
+        while let Some(request) = incoming.incoming().next().await {
+            let passphrase = request.stream_id().unwrap().as_str().into();
+            let key_size = request.key_size().clone();
+
+            if let Ok(mut sender) = request
+                .accept(Some(KeySettings {
+                    key_size,
+                    passphrase,
+                }))
+                .await
+            {
+                let mut stream =
+                    stream::iter(Some(Ok((Instant::now(), Bytes::from("asdf")))).into_iter());
+
+                tokio::spawn(async move {
+                    sender.send_all(&mut stream).await.unwrap();
+                    sender.close().await.unwrap();
+                    info!("Sender finished");
+                });
+            }
+        }
+    });
+
+    for key_size_bytes in [0, 16, 24, 32] {
+        SrtSocket::builder()
+            .encryption(key_size_bytes, "password128")
+            .call("127.0.0.1:2001", Some("password128"))
+            .await
+            .unwrap()
+            .close()
+            .await
+            .expect("server should use the advertised key size");
+    }
 
     server.close().await;
     listener.await.unwrap();


### PR DESCRIPTION
Currently, it is not possible to retrieve the caller's specified key size when handling a `ConnectionRequest`.

This means we must defer to the library to handle the key size. This presents a number of issues:
1. The library cannot currently handle key size mismatches (https://github.com/russelltg/srt-rs/issues/195).
    - This is especially problematic because it means one caller's bad request can shut down the server and drop all other callers' connections.
2. The library does not currently handle rejection properly (https://github.com/russelltg/srt-rs/issues/196), which involves rejecting on the basis of the passphrase and its corresponding key size.
3. The server implementation cannot retrieve the key size despite it being advertised in the caller's request. This prevents any custom handling of the key size.

---

This PR adds a key size field to the `ConnectionRequest` type, which serves as a workaround for 1 and 2 and a solution for 3.

It also includes:
- a simple test
- an example multiplex server that enforces password authorization and prevents key size mismatch errors